### PR TITLE
Update GitHub actions external images and fix a security issue 

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -11,24 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v6
+        uses: tj-actions/branch-names@v7
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -8,7 +8,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'CHANGELOG.md'

--- a/.github/workflows/preproc_docker_push.yml
+++ b/.github/workflows/preproc_docker_push.yml
@@ -11,25 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v5
+        uses: tj-actions/branch-names@v7
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         if: steps.branch-name.outputs.is_default == 'false'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ./utils/
           file: ./utils/Dockerfile

--- a/.github/workflows/stage_docker_push.yml
+++ b/.github/workflows/stage_docker_push.yml
@@ -14,24 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v6
+        uses: tj-actions/branch-names@v7
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
-        mongodb-version: ["3.6"]
+        python-version: [3.8]
+        mongodb-version: ["7"]
 
     steps:
 
     # Check out Scout code
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Set up python
     - name: Set up Python ${{ matrix.python-version}}
@@ -51,7 +51,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ utils/hg38_annotations/
 venv/
 *.egg-info
 .eggs
+.idea
 
 # node
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
  - Changes the main view's page title to be `sample_name` and adds `sample_name` and `case_id` to the header title
+ - Updated external images used in GitHub actions, including tj-actions/branch-names to v7 (fixes a security issue)
+ - Updated Python and MongoDB version used in tests workflow to 3.8 and 7 respectively
 ### Fixed
 
 ## [2.1.1]


### PR DESCRIPTION
This PR adds a functionality or fixes a bug:
- Update version of external tools used in GitHub actions
- Fix a [security issue](https://github.com/tj-actions/branch-names/releases/tag/v7.0.7) in tj-actions/branch-names tool by updating its version to latest 7
- Updated Python and MongoDB version used in tests workflow to 3.8 and 7 respectively

**How to test**:
1. All automatic tests should pass

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
