### PR TITLE
Makes `genomeBuild` get passed on in `drawTrack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Fixed
+- Pan able to exit chrosome when using genome build 17 
+
 ## [2.3]
 ### Added
 - Link out to Scout: introduce config variable for base URL

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -98,7 +98,7 @@ export async function drawTrack({
   exclude = [], force = false, ...kwargs
 }) {
   // update input field
-  const region = await limitRegionToChromosome({ chrom, start, end })
+  const region = await limitRegionToChromosome({ chrom, start, end, genomeBuild })
   updateInputField({ ...region })
   const trackContainer = document.getElementById('visualization-container')
   trackContainer.dispatchEvent(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Gens release. We apply semantic versioning. This is a major/minor/patch release for reasons.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
