### PR TITLE
bump version to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/)
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## unreleased
+## 3.0.2
 ### Fixed
 - Docker file syslog gives bad file descriptor (#101)
 

--- a/gens/__version__.py
+++ b/gens/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "3.0.1"
+VERSION = "3.0.2"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "tippy.js": "^6.3.2"
   },
   "name": "gens",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Interactive tool to visualize genomic copy number profiles from WGS data",
   "main": "gens.js",
   "scripts": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.0.2
 
 [metadata]
 description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="gens",
-    version="3.0.1",
+    version="3.0.2",
     description="Gens is a web-based interactive tool to visualize genomic copy number profiles from WGS data.",
     license="MIT",
     author="Ronja Grosz, Markus Johansson",


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

## 3.0.2
### Fixed
- Docker file syslog gives bad file descriptor (#101)

Looks good on stage:
<img width="796" height="423" alt="Screenshot 2025-09-08 at 15 38 38" src="https://github.com/user-attachments/assets/7b44246f-1c0e-46f5-997f-330d6896a5a5" />

<img width="501" height="225" alt="Screenshot 2025-09-08 at 16 02 58" src="https://github.com/user-attachments/assets/1a9859ea-dc09-4adc-99fa-e7d346889ab9" />


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
